### PR TITLE
Fixed a small bug in the analytical cop solver

### DIFF
--- a/copsolver/analytical_solver.py
+++ b/copsolver/analytical_solver.py
@@ -43,7 +43,7 @@ class AnalyticalSolver(COPSolver):
         if (len(gradients[0]) != len(gradients[1])):
             raise ValueError('Argument: The gradients must have the same length')
         if (gradients[0] == gradients[1]).all():
-            raise ValueError('Argument: the gradients cannot be the same')
+            return [0.5,0.5]
 
         r"""
         .. math::

--- a/tests/unit/test_copsolver.py
+++ b/tests/unit/test_copsolver.py
@@ -51,8 +51,7 @@ def test_analytical_differents_gradient_length():
 
 # analytical sovler cannot take the same gradients
 def test_analytical_same_gradient():
-    with pytest.raises(ValueError):
-        analytical.solve(gradient_same)
+    assert((analytical.solve(gradient_same) == [0.5,0.5]))
 
 
 # analytical solver gives correct alphas


### PR DESCRIPTION
Hey!

I fixed a small bug in the analytical cop solver: If both input gradients are equal, it should not raise an exception but return [0.5, 0.5] alphas. 

Greez,
Giancarlo